### PR TITLE
Add demoURL to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-cli-htmlbars": "^1.0.1"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://ef4.github.io/ember-sidebars/"
   }
 }


### PR DESCRIPTION
Enables emberobserver.com and emberaddons.com to show a nice demo link.
