### PR TITLE
use {{#with}} to remove some repetition

### DIFF
--- a/addon/templates/components/show-sidebar.hbs
+++ b/addon/templates/components/show-sidebar.hbs
@@ -1,3 +1,3 @@
-{{#if (get sidebars.actives _name)}}
-  {{component (get (get sidebars.actives _name) 'component') }}
-{{/if}}
+{{#with (get sidebars.actives _name) as |name|}}
+  {{component (get name 'component') }}
+{{/with}}


### PR DESCRIPTION
A falsy with doesn't render, so we can use it
here to remove a dup `(get sidebars.actives _name)`
