### PR TITLE
[DON'T MERGE] demonstrate the broken "overlap" behavior

### DIFF
--- a/tests/dummy/app/controllers/second-2.js
+++ b/tests/dummy/app/controllers/second-2.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  init() {
+    this.set('handled', Ember.A());
+  },
+  actions: {
+    handleIt() {
+      this.get('handled').pushObject("I handled an event");
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('second');
+  this.route('second-2');
   this.route('third');
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,10 +22,11 @@
     <nav>
       {{#link-to 'index'}}First Page{{/link-to}}
       {{#link-to 'second'}}Second Page{{/link-to}}
+      {{#link-to 'second-2'}}Second-2 Page{{/link-to}}
       {{#link-to 'third'}}Third Page{{/link-to}}
     </nav>
 
-    {{outlet}}
+    {{liquid-outlet use="cross-fade"}}
   </main>
 
   <div class="right-sidebar">

--- a/tests/dummy/app/templates/second-2.hbs
+++ b/tests/dummy/app/templates/second-2.hbs
@@ -1,0 +1,11 @@
+{{!- BEGIN-SNIPPET second }}
+<div>This is the second page.</div>
+{{#each handled as |h|}}
+  <div>{{h}}</div>
+{{/each}}
+
+{{in-sidebar name="tools"
+             show=(component "second-tools" doIt=(action "handleIt") ) }}
+{{!- END-SNIPPET }}
+
+{{code-snippet name="second.hbs"}}


### PR DESCRIPTION
I just 1) changed application's outlet to liquid-outlet
with cross-fade and 2) duplicated 'second' route
to 'second-2'

If you click between 'second' and 'second-2' routes,
you'll see the "now you see it now you don't"
behavior w the sidebar due to timing issues
when there's two templates on the screen
rendering into a sidebar
