### PR TITLE
in-sidebar: set tagName: ''

### DIFF
--- a/addon/components/in-sidebar.js
+++ b/addon/components/in-sidebar.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/in-sidebar';
 
 export default Ember.Component.extend({
+  tagName: '',
   layout,
   sidebars: Ember.inject.service('ember-sidebars'),
   willRender() {


### PR DESCRIPTION
Before this change {{in-sidebar}} would leave a
div hanging around, which cluttered the DOM
and could mess up CSS selectors.
